### PR TITLE
Remove duplicated kblayouts and colorschemes installation

### DIFF
--- a/qmltermwidget.pro
+++ b/qmltermwidget.pro
@@ -51,15 +51,11 @@ qmldir.path += $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 
 colorschemes.files = $$PWD/lib/color-schemes/*
 colorschemes.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/color-schemes
-colorschemes2.files = $$PWD/lib/color-schemes/historic/*
-colorschemes2.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/color-schemes/historic
 
 kblayouts.files = $$PWD/lib/kb-layouts/*
 kblayouts.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/kb-layouts
-kblayouts2.files = $$PWD/lib/kb-layouts/historic/*
-kblayouts2.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/kb-layouts/historic
 
 scrollbar.files = $$PWD/src/QMLTermScrollbar.qml
 scrollbar.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 
-INSTALLS += target qmldir assets colorschemes colorschemes2 kblayouts kblayouts2 scrollbar
+INSTALLS += target qmldir assets colorschemes kblayouts scrollbar


### PR DESCRIPTION
The 2nd installation line fails because the files already got installed with the first line